### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/vharmash/harmashv.pro/security/code-scanning/1](https://github.com/vharmash/harmashv.pro/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. Since the workflow only performs basic CI tasks, the minimal required permission is `contents: read`. This ensures that the `GITHUB_TOKEN` has only the necessary access to repository contents and no write permissions.

The `permissions` block should be added at the root level of the workflow file, so it applies to all jobs in the workflow. This change does not affect the functionality of the workflow but improves its security posture.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
